### PR TITLE
fix: too much keywords for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A package built to access helloasso api, https://api.helloasso.co
 homepage = "https://github.com/Mattherix/hello-asso"
 repository = "https://github.com/Mattherix/hello-asso"
 readme = "README.md"
-keywords = ["helloasso", "nonprofit", "webapi", "api", "wrapper", "api-bindings"]
+keywords = ["helloasso", "nonprofit", "webapi", "api", "wrapper"]
 categories = ["api-bindings"]
 exclude = [
     ".github/*",


### PR DESCRIPTION
You can only have 5 keywords on crates.io